### PR TITLE
Edit visualize_model_performance by adding methods package, fix #106

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,8 @@ Imports:
     gplots,
     doParallel,
     cluster,
-    digest
+    digest,
+    methods
 Suggests:
     testthat,
     knitr,

--- a/R/celda_C.R
+++ b/R/celda_C.R
@@ -411,7 +411,7 @@ visualize_model_performance.celda_C = function(celda.list, method="perplexity",
   # plotted, so log 'em first
   if (method %in% c("perplexity", "harmonic")) {
     performance.metric = lapply(performance.metric, log)
-    performance.metric = new("mpfr", unlist(performance.metric))
+    performance.metric = methods::new("mpfr", unlist(performance.metric))
     performance.metric = as.numeric(performance.metric)
   }
   

--- a/R/celda_G.R
+++ b/R/celda_G.R
@@ -499,7 +499,7 @@ visualize_model_performance.celda_G = function(celda.list, method="perplexity",
   # plotted, so log 'em first
   if (method %in% c("perplexity", "harmonic")) {
     performance.metric = lapply(performance.metric, log)
-    performance.metric = new("mpfr", unlist(performance.metric))
+    performance.metric = methods::new("mpfr", unlist(performance.metric))
     performance.metric = as.numeric(performance.metric)
   }
   

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,2 +1,4 @@
+Sys.setenv("R_TESTS" ="")
 library(testthat)
 test_check("celda")
+

--- a/tests/testthat/test-celda_C.R
+++ b/tests/testthat/test-celda_C.R
@@ -3,8 +3,11 @@ library(celda)
 context("Testing celda_C")
 
 celdac <- simulateCells.celda_C(K=10)
-#celdaC.res <- celda(counts=celdac$counts,model="celda_C",nchains=1,cores=4,K=10)
+celdaC.res <- celda(counts=celdac$counts,model="celda_C",nchains=1,cores=4,K=10)
 
+test_that("CheckingVisualizeModelPerformace",{
+	expect_equal(TRUE, all(!is.na(visualize_model_performance(celdaC.res))))
+	})
 #test_that("finalClusterAssignment.celda_C",{
 #  expect_equal(celdaC.res$res.list[[1]]$z, finalClusterAssignment(celdaC.res$res.list[[1]]))
 #})

--- a/tests/testthat/test-celda_C.R
+++ b/tests/testthat/test-celda_C.R
@@ -3,7 +3,7 @@ library(celda)
 context("Testing celda_C")
 
 celdac <- simulateCells.celda_C(K=10)
-celdaC.res <- celda(counts=celdac$counts,model="celda_C",nchains=1,cores=4,K=10)
+celdaC.res <- celda(counts=celdac$counts, model="celda_C", nchains=1, K=10)
 
 test_that("CheckingVisualizeModelPerformace",{
 	expect_equal(TRUE, all(!is.na(visualize_model_performance(celdaC.res))))

--- a/tests/testthat/test-celda_CG.R
+++ b/tests/testthat/test-celda_CG.R
@@ -3,7 +3,7 @@ library(celda)
 context("Testing celda_CG")
 
 celdacg <- simulateCells.celda_CG(K=10,L=10)
-celdaCG.res <- celda(counts=celdacg$counts,model="celda_CG",nchains=1,cores=4,K=10,L=10)
+celdaCG.res <- celda(counts=celdacg$counts, model="celda_CG", nchains=1, K=10, L=10)
 
 test_that("CheckingVisualizeModelPerformace",{
         expect_equal(TRUE, all(!is.na(visualize_model_performance(celdaCG.res))))

--- a/tests/testthat/test-celda_CG.R
+++ b/tests/testthat/test-celda_CG.R
@@ -1,1 +1,11 @@
 # celda_CG.R
+library(celda)
+context("Testing celda_CG")
+
+celdacg <- simulateCells.celda_CG(K=10,L=10)
+celdaCG.res <- celda(counts=celdacg$counts,model="celda_CG",nchains=1,cores=4,K=10,L=10)
+
+test_that("CheckingVisualizeModelPerformace",{
+        expect_equal(TRUE, all(!is.na(visualize_model_performance(celdacg))))
+        })
+

--- a/tests/testthat/test-celda_CG.R
+++ b/tests/testthat/test-celda_CG.R
@@ -6,6 +6,6 @@ celdacg <- simulateCells.celda_CG(K=10,L=10)
 celdaCG.res <- celda(counts=celdacg$counts,model="celda_CG",nchains=1,cores=4,K=10,L=10)
 
 test_that("CheckingVisualizeModelPerformace",{
-        expect_equal(TRUE, all(!is.na(visualize_model_performance(celdacg))))
+        expect_equal(TRUE, all(!is.na(visualize_model_performance(celdaCG.res))))
         })
 

--- a/tests/testthat/test-celda_G.R
+++ b/tests/testthat/test-celda_G.R
@@ -4,7 +4,7 @@ context("Testing celda_G")
 
 celdag <- simulateCells.celda_G(L=10)
 
-celdaG.res <- celda(counts=celdag$counts,model="celda_G",nchains=1,cores=4,L=10)
+celdaG.res <- celda(counts=celdag$counts, model="celda_G", nchains=1, L=10)
 
 test_that("CheckingVisualizeModelPerformace",{
         expect_equal(TRUE, all(!is.na(visualize_model_performance(celdaG.res))))

--- a/tests/testthat/test-celda_G.R
+++ b/tests/testthat/test-celda_G.R
@@ -1,1 +1,12 @@
-# celda_C.R
+#celda_G
+library(celda)
+context("Testing celda_G")
+
+celdag <- simulateCells.celda_G(L=10)
+
+celdaG.res <- celda(counts=celdag$counts,model="celda_G",nchains=1,cores=4,L=10)
+
+test_that("CheckingVisualizeModelPerformace",{
+        expect_equal(TRUE, all(!is.na(visualize_model_performance(celdaG.res))))
+        })
+


### PR DESCRIPTION
Tests done (all via qsub to scc):
-w/o "methods::new" in visualize_model_performance, methods not in DESCRIPTION: error, function "new" not found
-with "methods::new" in visualize_model_performance, methods not in DESCRIPTION: no error, plots outputted
-with "methods::new" in visualize_model_performance, methods package in DESCRIPTION: no error, plots outputted, no difference in plots compared to above plots.