### PR TITLE
Require class check on count matrix

### DIFF
--- a/R/celda.R
+++ b/R/celda.R
@@ -21,7 +21,6 @@ available_models = c("celda_C", "celda_G", "celda_CG")
 #' @param y.init Initial values of y. If NULL, y will be randomly sampled. Default NULL. (celda_G / celda_CG only)
 #' @param stop.iter Number of iterations without improvement in the log likelihood to stop the Gibbs sampler. Default 10.
 #' @param split.on.iter On every 'split.on.iter' iteration, a heuristic will be applied to determine if a gene/cell cluster should be reassigned and another gene/cell cluster should be split into two clusters. Default 10.
-#' @param process.counts Whether to cast the counts matrix to integer and round(). Defaults to TRUE.
 #' @param nchains The number of chains of Gibbs sampling to run for every combination of K/L parameters. Defaults to 1 (celda_G / celda_CG only)
 #' @param bestChainsOnly Return only the best chain (by final log-likelihood) per K/L combination.
 #' @param cores The number of cores to use for parallell Gibbs sampling. Defaults to 1.
@@ -33,9 +32,9 @@ available_models = c("celda_C", "celda_G", "celda_CG")
 #' @export
 celda = function(counts, model, sample.label=NULL, K=NULL, L=NULL, alpha=1, beta=1, 
                  delta=1, gamma=1, max.iter=200, z.init=NULL, y.init=NULL,
-                 stop.iter=10, split.on.iter=10, process.counts=FALSE, 
-                 nchains=1, bestChainsOnly=TRUE, cores=1, 
-                 seed=12345, verbose=FALSE, logfile_prefix="Celda") {
+                 stop.iter=10, split.on.iter=10, nchains=1, 
+                 bestChainsOnly=TRUE, cores=1, seed=12345, verbose=FALSE, 
+                 logfile_prefix="Celda") {
  
   validateArgs(counts, model, sample.label, nchains, cores, seed, K=K, L=L)
   params.list = buildParamList(counts, model, sample.label, alpha, beta, delta,

--- a/R/celda.R
+++ b/R/celda.R
@@ -39,7 +39,7 @@ celda = function(counts, model, sample.label=NULL, K=NULL, L=NULL, alpha=1, beta
   validateArgs(counts, model, sample.label, nchains, cores, seed, K=K, L=L)
   params.list = buildParamList(counts, model, sample.label, alpha, beta, delta,
                                gamma, max.iter, z.init, y.init, stop.iter, split.on.iter,
-                               process.counts, nchains, cores, seed)
+                               nchains, cores, seed)
   
   # Redirect stderr from the worker threads if user asks for verbose
   if(!is.null(logfile_prefix)) {
@@ -110,13 +110,12 @@ celda = function(counts, model, sample.label=NULL, K=NULL, L=NULL, alpha=1, beta
 # validating the provided parameters along the way
 buildParamList = function(counts, model, sample.label, alpha, beta, delta,
                           gamma, max.iter, z.init, y.init, stop.iter, split.on.iter,
-                          process.counts, nchains, cores, seed) {
+                          nchains, cores, seed) {
   
   params.list = list(counts=counts,
                      max.iter=max.iter,
                      stop.iter=stop.iter,
-                     split.on.iter=split.on.iter,
-                     process.counts=process.counts)
+                     split.on.iter=split.on.iter)
   
   if (model %in% c("celda_C", "celda_CG")) {
     params.list$alpha = alpha

--- a/R/celda_C.R
+++ b/R/celda_C.R
@@ -43,19 +43,16 @@
 #' @param count.checksum An MD5 checksum for the provided counts matrix
 #' @param seed Parameter to set.seed() for random number generation
 #' @param z.init Initial values of z. If NULL, z will be randomly sampled. Default NULL.
-#' @param process.counts Whether to cast the counts matrix to integer and round(). Defaults to TRUE.
 #' @param logfile If NULL, messages will be displayed as normal. If set to a file name, messages will be redirected messages to the file. Default NULL.
 #' @return An object of class celda_C with clustering results and Gibbs sampling statistics
 #' @export
 celda_C = function(counts, sample.label=NULL, K, alpha=1, beta=1, 
                  	 stop.iter = 10, max.iter=200, split.on.iter=10, split.on.last=TRUE,
                  	 count.checksum=NULL, seed=12345,
-                 	 z.init = NULL, process.counts=TRUE, logfile=NULL) {
+                 	 z.init = NULL, logfile=NULL) {
   
   ## Error checking and variable processing
-  if (isTRUE(process.counts)) {
-    counts = processCounts(counts)  
-  }
+  counts = processCounts(counts)  
     
   s = processSampleLabels(sample.label, ncol(counts))
   if (is.null(sample.label)) {
@@ -238,7 +235,7 @@ simulateCells.celda_C = function(model, S=10, C.Range=c(10, 100), N.Range=c(100,
   class(result) = "celda_C" 
   result = reorder.celda_C(counts = cell.counts, res = result)
   
-  return(list(z=result$z, counts=cell.counts, sample.label=cell.sample.label, K=K, alpha=alpha, beta=beta, C.Range=C.Range, N.Range=N.Range, S=S))
+  return(list(z=result$z, counts=processCounts(cell.counts), sample.label=cell.sample.label, K=K, alpha=alpha, beta=beta, C.Range=C.Range, N.Range=N.Range, S=S))
 }
 
 

--- a/R/celda_CG.R
+++ b/R/celda_CG.R
@@ -49,19 +49,16 @@
 #' @param count.checksum An MD5 checksum for the provided counts matrix
 #' @param z.init Initial values of z. If NULL, z will be randomly sampled. Default NULL.
 #' @param y.init Initial values of y. If NULL, y will be randomly sampled. Default NULL.
-#' @param process.counts Whether to cast the counts matrix to integer and round(). Defaults to TRUE.
 #' @param logfile The name of the logfile to redirect messages to.
 #' @export
 celda_CG = function(counts, sample.label=NULL, K, L,
                     alpha=1, beta=1, delta=1, gamma=1, 
                     stop.iter = 10, max.iter=200, split.on.iter=10, split.on.last=TRUE,
                     seed=12345, count.checksum=NULL,
-                    z.init = NULL, y.init = NULL, process.counts=TRUE, logfile=NULL) {
+                    z.init = NULL, y.init = NULL, logfile=NULL) {
  
   ## Error checking and variable processing
-  if (isTRUE(processCounts)) {
-    counts = processCounts(counts)
-  }
+  counts = processCounts(counts)
     
   s = processSampleLabels(sample.label, ncol(counts))
   if (is.null(sample.label)) {
@@ -292,7 +289,7 @@ simulateCells.celda_CG = function(model, S=10, C.Range=c(50,100), N.Range=c(500,
   class(result) = "celda_CG" 
   result = reorder.celda_CG(counts = cell.counts, res = result)
   
-  return(list(z=result$z, y=result$y, sample.label=cell.sample.label, counts=cell.counts, K=K, L=L, C.Range=C.Range, N.Range=N.Range, S=S, alpha=alpha, beta=beta, gamma=gamma, delta=delta, theta=theta, phi=phi, psi=psi, eta=eta, seed=seed))
+  return(list(z=result$z, y=result$y, sample.label=cell.sample.label, counts=processCounts(cell.counts), K=K, L=L, C.Range=C.Range, N.Range=N.Range, S=S, alpha=alpha, beta=beta, gamma=gamma, delta=delta, theta=theta, phi=phi, psi=psi, eta=eta, seed=seed))
 }
 
 

--- a/R/celda_G.R
+++ b/R/celda_G.R
@@ -48,19 +48,16 @@
 #' @param count.checksum An MD5 checksum for the provided counts matrix
 #' @param seed Parameter to set.seed() for random number generation.
 #' @param y.init Initial values of y. If NULL, y will be randomly sampled. Default NULL.
-#' @param process.counts Whether to cast the counts matrix to integer and round(). Defaults to TRUE.
 #' @param logfile The name of the logfile to redirect messages to.
 #' @keywords LDA gene clustering gibbs
 #' @export
 celda_G = function(counts, L, beta=1, delta=1, gamma=1,
 					stop.iter=10, max.iter=200, split.on.iter=10, split.on.last=TRUE,
 					count.checksum=NULL, seed=12345, 
-					y.init=NULL, process.counts=TRUE, logfile=NULL) {
+					y.init=NULL, logfile=NULL) {
 
   ## Error checking and variable processing
-  if (isTRUE(process.counts)) {
-    counts = processCounts(counts)  
-  }
+  counts = processCounts(counts)  
   counts.t = t(counts)
   
   if(is.null(count.checksum)) {
@@ -280,7 +277,7 @@ simulateCells.celda_G = function(model, C=100, N.Range=c(500,5000),  G=1000,
   class(result) = "celda_G" 
   result = reorder.celda_G(counts = cell.counts, res = result)  
   
-  return(list(y=result$y, counts=cell.counts, L=L, beta=beta, delta=delta, gamma=gamma, phi=phi, psi=psi, eta=eta, seed=seed))
+  return(list(y=result$y, counts=processCounts(cell.counts), L=L, beta=beta, delta=delta, gamma=gamma, phi=phi, psi=psi, eta=eta, seed=seed))
 }
 
 

--- a/R/celda_functions.R
+++ b/R/celda_functions.R
@@ -351,9 +351,9 @@ rowsum.y = function(counts, y, L) {
 
 
 processCounts = function(counts) {
-  if(class(counts) != "integer") {
+  if (typeof(counts) != "integer") {
     counts = round(counts)
-    class(counts) = "integer"
+    storage.mode(counts) = "integer"
   }
   return(counts)  
 }

--- a/man/celda.Rd
+++ b/man/celda.Rd
@@ -6,9 +6,9 @@
 \usage{
 celda(counts, model, sample.label = NULL, K = NULL, L = NULL, alpha = 1,
   beta = 1, delta = 1, gamma = 1, max.iter = 200, z.init = NULL,
-  y.init = NULL, stop.iter = 10, split.on.iter = 10,
-  process.counts = FALSE, nchains = 1, bestChainsOnly = TRUE, cores = 1,
-  seed = 12345, verbose = FALSE, logfile_prefix = "Celda")
+  y.init = NULL, stop.iter = 10, split.on.iter = 10, nchains = 1,
+  bestChainsOnly = TRUE, cores = 1, seed = 12345, verbose = FALSE,
+  logfile_prefix = "Celda")
 }
 \arguments{
 \item{counts}{A count matrix}
@@ -38,8 +38,6 @@ celda(counts, model, sample.label = NULL, K = NULL, L = NULL, alpha = 1,
 \item{stop.iter}{Number of iterations without improvement in the log likelihood to stop the Gibbs sampler. Default 10.}
 
 \item{split.on.iter}{On every 'split.on.iter' iteration, a heuristic will be applied to determine if a gene/cell cluster should be reassigned and another gene/cell cluster should be split into two clusters. Default 10.}
-
-\item{process.counts}{Whether to cast the counts matrix to integer and round(). Defaults to TRUE.}
 
 \item{nchains}{The number of chains of Gibbs sampling to run for every combination of K/L parameters. Defaults to 1 (celda_G / celda_CG only)}
 

--- a/man/celda_C.Rd
+++ b/man/celda_C.Rd
@@ -7,7 +7,7 @@
 celda_C(counts, sample.label = NULL, K, alpha = 1, beta = 1,
   stop.iter = 10, max.iter = 200, split.on.iter = 10,
   split.on.last = TRUE, count.checksum = NULL, seed = 12345,
-  z.init = NULL, process.counts = TRUE, logfile = NULL)
+  z.init = NULL, logfile = NULL)
 }
 \arguments{
 \item{counts}{A numeric count matrix}
@@ -33,8 +33,6 @@ celda_C(counts, sample.label = NULL, K, alpha = 1, beta = 1,
 \item{seed}{Parameter to set.seed() for random number generation}
 
 \item{z.init}{Initial values of z. If NULL, z will be randomly sampled. Default NULL.}
-
-\item{process.counts}{Whether to cast the counts matrix to integer and round(). Defaults to TRUE.}
 
 \item{logfile}{If NULL, messages will be displayed as normal. If set to a file name, messages will be redirected messages to the file. Default NULL.}
 }

--- a/man/celda_CG.Rd
+++ b/man/celda_CG.Rd
@@ -7,8 +7,7 @@
 celda_CG(counts, sample.label = NULL, K, L, alpha = 1, beta = 1,
   delta = 1, gamma = 1, stop.iter = 10, max.iter = 200,
   split.on.iter = 10, split.on.last = TRUE, seed = 12345,
-  count.checksum = NULL, z.init = NULL, y.init = NULL,
-  process.counts = TRUE, logfile = NULL)
+  count.checksum = NULL, z.init = NULL, y.init = NULL, logfile = NULL)
 }
 \arguments{
 \item{counts}{A numeric count matrix.}
@@ -42,8 +41,6 @@ celda_CG(counts, sample.label = NULL, K, L, alpha = 1, beta = 1,
 \item{z.init}{Initial values of z. If NULL, z will be randomly sampled. Default NULL.}
 
 \item{y.init}{Initial values of y. If NULL, y will be randomly sampled. Default NULL.}
-
-\item{process.counts}{Whether to cast the counts matrix to integer and round(). Defaults to TRUE.}
 
 \item{logfile}{The name of the logfile to redirect messages to.}
 }

--- a/man/celda_G.Rd
+++ b/man/celda_G.Rd
@@ -6,8 +6,7 @@
 \usage{
 celda_G(counts, L, beta = 1, delta = 1, gamma = 1, stop.iter = 10,
   max.iter = 200, split.on.iter = 10, split.on.last = TRUE,
-  count.checksum = NULL, seed = 12345, y.init = NULL,
-  process.counts = TRUE, logfile = NULL)
+  count.checksum = NULL, seed = 12345, y.init = NULL, logfile = NULL)
 }
 \arguments{
 \item{counts}{A numeric count matrix}
@@ -33,8 +32,6 @@ celda_G(counts, L, beta = 1, delta = 1, gamma = 1, stop.iter = 10,
 \item{seed}{Parameter to set.seed() for random number generation.}
 
 \item{y.init}{Initial values of y. If NULL, y will be randomly sampled. Default NULL.}
-
-\item{process.counts}{Whether to cast the counts matrix to integer and round(). Defaults to TRUE.}
 
 \item{logfile}{The name of the logfile to redirect messages to.}
 }

--- a/tests/testthat/test-celda_C.R
+++ b/tests/testthat/test-celda_C.R
@@ -38,7 +38,7 @@ test_that(desc = "calculateLoglikFromVariables.celda_C returns correct output fo
 
 test_that(desc = "simulateCells.celda_C returns correctly typed output", {
   sim.res = simulateCells(model="celda_C")
-  expect_equal(class(sim.res$counts), "integer")
+  expect_equal(typeof(sim.res$counts), "integer")
 })
 
 #normalizeCounts

--- a/tests/testthat/test-celda_C.R
+++ b/tests/testthat/test-celda_C.R
@@ -36,6 +36,10 @@ test_that(desc = "calculateLoglikFromVariables.celda_C returns correct output fo
                0)
 })
 
+test_that(desc = "simulateCells.celda_C returns correctly typed output", {
+  sim.res = simulateCells(model="celda_C")
+  expect_equal(class(sim.res$counts), "integer")
+})
 
 #normalizeCounts
 test_that(desc = "Checking normalizeCounts doesn't change dimensions",{

--- a/tests/testthat/test-celda_CG.R
+++ b/tests/testthat/test-celda_CG.R
@@ -49,6 +49,10 @@ test_that(desc = "calculateLoglikFromVariables.celda_CG returns correct output f
                0)
 })
 
+test_that(desc = "simulateCells.celda_CG returns correctly typed output", {
+  sim.res = simulateCells(model="celda_CG")
+  expect_equal(class(sim.res$counts), "integer")
+})
 
 #normalizeCounts
 test_that(desc = "Making sure normalizeCounts doesn't change dimensions",{

--- a/tests/testthat/test-celda_CG.R
+++ b/tests/testthat/test-celda_CG.R
@@ -51,7 +51,7 @@ test_that(desc = "calculateLoglikFromVariables.celda_CG returns correct output f
 
 test_that(desc = "simulateCells.celda_CG returns correctly typed output", {
   sim.res = simulateCells(model="celda_CG")
-  expect_equal(class(sim.res$counts), "integer")
+  expect_equal(typeof(sim.res$counts), "integer")
 })
 
 #normalizeCounts

--- a/tests/testthat/test-celda_G.R
+++ b/tests/testthat/test-celda_G.R
@@ -36,7 +36,7 @@ test_that(desc = "calculateLoglikFromVariables.celda_G returns correct output fo
 
 test_that(desc = "simulateCells.celda_G returns correctly typed output", {
   sim.res = simulateCells(model="celda_G")
-  expect_equal(class(sim.res$counts), "integer")
+  expect_equal(typeof(sim.res$counts), "integer")
 })
 
 

--- a/tests/testthat/test-celda_G.R
+++ b/tests/testthat/test-celda_G.R
@@ -33,6 +33,13 @@ test_that(desc = "calculateLoglikFromVariables.celda_G returns correct output fo
                0)
 })
 
+
+test_that(desc = "simulateCells.celda_G returns correctly typed output", {
+  sim.res = simulateCells(model="celda_G")
+  expect_equal(class(sim.res$counts), "integer")
+})
+
+
 #normalizeCounts
 test_that(desc = "Making sure normalizeCounts doesn't change dimensions of counts matrix",{
   norm.counts <- normalizeCounts(counts.matrix)


### PR DESCRIPTION
Require that all provided count matrices are checked to see if they're integer type, and if not, casting them to be that type.
Explicitly cast simulateCells() simulated count matrices to integer. Added unit tests to ensure this happens for this function.

Fixes #236 