### PR TITLE
replace normalizeCounts by normalizeCounts.internal in celda_C: EM

### DIFF
--- a/R/celda_C.R
+++ b/R/celda_C.R
@@ -222,8 +222,8 @@ cC.calcGibbsProbZ = function(counts, m.CP.by.S, n.G.by.CP, n.by.C, n.CP, z, s, K
 cC.calcEMProbZ = function(counts, m.CP.by.S, n.G.by.CP, n.by.C, n.CP, z, s, K, nG, nM, alpha, beta, do.sample=TRUE) {
 
   ## Expectation given current cell population labels
-  theta = log(normalizeCounts(m.CP.by.S + alpha, scale.factor=1))
-  phi = log(normalizeCounts(n.G.by.CP + beta, scale.factor=1))
+  theta = log(normalizeCounts.internal(m.CP.by.S + alpha))
+  phi = log(normalizeCounts.internal(n.G.by.CP + beta))
   
   ## Maximization to find best label for each cell
   probs = eigenMatMultInt(phi, counts) + theta[, s]  

--- a/R/matrixSums.R
+++ b/R/matrixSums.R
@@ -28,3 +28,29 @@ colSumByGroupChange <- function(x, px, group, pgroup, K) {
   return(res)
 }
 
+
+#' @useDynLib celda _rowSumByGroup_real 
+rowSumByGroup.real <- function(x, group, L) {
+  group <- factor(group, levels=1:L)
+  res <- .Call("_rowSumByGroup_real", x, group)
+  return(res)
+}
+
+#' @useDynLib celda _colSumByGroup_real
+colSumByGroup.real <- function(x, group, K) {
+  group <- factor(group, levels=1:K)
+  res <- .Call("_colSumByGroup_real", x, group)
+  return(res)
+}
+
+#' @useDynLib celda _mvMult
+mvMult <- function(x, v, by.row) {
+  res <- .Call("_mvMult", x, v, by.row) 
+  return(res)
+}
+
+#' @useDynLib celda _mvAdd 
+mvAdd <- function(x, v, by.row) {
+  res <- .Call("_mvAdd", x, v, by.row)
+  return(res)
+}

--- a/R/matrixSums.R
+++ b/R/matrixSums.R
@@ -54,3 +54,13 @@ mvAdd <- function(x, v, by.row) {
   res <- .Call("_mvAdd", x, v, by.row)
   return(res)
 }
+
+#' @useDynLib celda _mvAdd 
+normalizeCounts.internal <- function(x) {
+  if (is.integer(x)) {
+    res <- .Call("_mvMult", x + 1e-20, 1/colSums(x), by.row=FALSE)
+  } else {
+    res <- .Call("_mvMult", x, 1/colSums(x), by.row=FALSE)
+    }
+  return(res)
+}

--- a/R/matrixSums.R
+++ b/R/matrixSums.R
@@ -29,17 +29,17 @@ colSumByGroupChange <- function(x, px, group, pgroup, K) {
 }
 
 
-#' @useDynLib celda _rowSumByGroup_real 
-rowSumByGroup.real <- function(x, group, L) {
+#' @useDynLib celda _rowSumByGroup_numeric 
+rowSumByGroup.numeric <- function(x, group, L) {
   group <- factor(group, levels=1:L)
-  res <- .Call("_rowSumByGroup_real", x, group)
+  res <- .Call("_rowSumByGroup_numeric", x, group)
   return(res)
 }
 
-#' @useDynLib celda _colSumByGroup_real
-colSumByGroup.real <- function(x, group, K) {
+#' @useDynLib celda _colSumByGroup_numeric
+colSumByGroup.numeric <- function(x, group, K) {
   group <- factor(group, levels=1:K)
-  res <- .Call("_colSumByGroup_real", x, group)
+  res <- .Call("_colSumByGroup_numeric", x, group)
   return(res)
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -20,23 +20,23 @@ END_RCPP
 }
 
 RcppExport SEXP _colSumByGroup(SEXP, SEXP);
-RcppExport SEXP _colSumByGroup_real(SEXP, SEXP);
+RcppExport SEXP _colSumByGroup_numeric(SEXP, SEXP);
 RcppExport SEXP _colSumByGroupChange(SEXP, SEXP, SEXP, SEXP);
 RcppExport SEXP _mvAdd(SEXP, SEXP, SEXP);
 RcppExport SEXP _mvMult(SEXP, SEXP, SEXP);
 RcppExport SEXP _rowSumByGroup(SEXP, SEXP);
-RcppExport SEXP _rowSumByGroup_real(SEXP, SEXP);
+RcppExport SEXP _rowSumByGroup_numeric(SEXP, SEXP);
 RcppExport SEXP _rowSumByGroupChange(SEXP, SEXP, SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_celda_eigenMatMultInt", (DL_FUNC) &_celda_eigenMatMultInt, 2},
     {"_colSumByGroup",         (DL_FUNC) &_colSumByGroup,         2},
-    {"_colSumByGroup_real",    (DL_FUNC) &_colSumByGroup_real,    2},
+    {"_colSumByGroup_numeric", (DL_FUNC) &_colSumByGroup_numeric, 2},
     {"_colSumByGroupChange",   (DL_FUNC) &_colSumByGroupChange,   4},
     {"_mvAdd",                 (DL_FUNC) &_mvAdd,                 3},
     {"_mvMult",                (DL_FUNC) &_mvMult,                3},
     {"_rowSumByGroup",         (DL_FUNC) &_rowSumByGroup,         2},
-    {"_rowSumByGroup_real",    (DL_FUNC) &_rowSumByGroup_real,    2},
+    {"_rowSumByGroup_numeric", (DL_FUNC) &_rowSumByGroup_numeric, 2},
     {"_rowSumByGroupChange",   (DL_FUNC) &_rowSumByGroupChange,   4},
     {NULL, NULL, 0}
 };

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -20,15 +20,23 @@ END_RCPP
 }
 
 RcppExport SEXP _colSumByGroup(SEXP, SEXP);
+RcppExport SEXP _colSumByGroup_real(SEXP, SEXP);
 RcppExport SEXP _colSumByGroupChange(SEXP, SEXP, SEXP, SEXP);
+RcppExport SEXP _mvAdd(SEXP, SEXP, SEXP);
+RcppExport SEXP _mvMult(SEXP, SEXP, SEXP);
 RcppExport SEXP _rowSumByGroup(SEXP, SEXP);
+RcppExport SEXP _rowSumByGroup_real(SEXP, SEXP);
 RcppExport SEXP _rowSumByGroupChange(SEXP, SEXP, SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
     {"_celda_eigenMatMultInt", (DL_FUNC) &_celda_eigenMatMultInt, 2},
     {"_colSumByGroup",         (DL_FUNC) &_colSumByGroup,         2},
+    {"_colSumByGroup_real",    (DL_FUNC) &_colSumByGroup_real,    2},
     {"_colSumByGroupChange",   (DL_FUNC) &_colSumByGroupChange,   4},
+    {"_mvAdd",                 (DL_FUNC) &_mvAdd,                 3},
+    {"_mvMult",                (DL_FUNC) &_mvMult,                3},
     {"_rowSumByGroup",         (DL_FUNC) &_rowSumByGroup,         2},
+    {"_rowSumByGroup_real",    (DL_FUNC) &_rowSumByGroup_real,    2},
     {"_rowSumByGroupChange",   (DL_FUNC) &_rowSumByGroupChange,   4},
     {NULL, NULL, 0}
 };

--- a/src/matrixSums.c
+++ b/src/matrixSums.c
@@ -2,6 +2,8 @@
 #include <Rinternals.h>
 #include <R_ext/RS.h>
 
+
+
 SEXP _rowSumByGroup(SEXP R_x, SEXP R_group)
 {
   int i, j;
@@ -177,4 +179,194 @@ SEXP _colSumByGroupChange(SEXP R_x, SEXP R_px, SEXP R_group, SEXP R_pgroup)
 
   return(R_px);
 }
+
+
+
+
+SEXP _mvAdd(SEXP R_m, SEXP R_v, SEXP R_by_row) {
+  int i, j; 
+  int nr = nrows(R_m);
+  int nc = ncols(R_m);
+  double *x = REAL(R_m); 
+  double *v = REAL(R_v);
+  int by_row = asLogical(R_by_row);
+	
+  // If the length of the vector and the length of the corresponding dimension of the matrix do not match, throw an error
+  if  (!by_row) {
+  	if (LENGTH(R_v) != nc ) {
+    	error("The length of the vector must match the number of columns in the matrix");
+    	}
+  }
+  if ( by_row) {
+  	if (LENGTH(R_v) != nr ) {
+  		error("The length of the vector must match the number of rows in the matrix");
+  	}
+  }
+
+  // Allocate a variable for the return matrix
+  SEXP R_ans;
+  PROTECT(R_ans = allocMatrix(REALSXP, nr, nc));
+  // Set a pointer to the return matrix and initialize the memory
+  double *ans = REAL(R_ans);
+  Memzero(ans, nr * nc);
+
+  if (by_row) { 
+  	// element-wise addition of the i-th row of the matrix to i-th element of the vector
+  	for (j = 0; j < nc; j++) {
+    	for (i = 0; i < nr; i++) {
+      		ans[j * nr + i] = x[j * nr + i] + v[i];
+  		}
+  	}
+  }
+  if (!by_row) {
+  	// element-wise addition of the j-th column of the matrix to j-th element of the vector
+  	for (j = 0; j < nc; j++) {
+    	for (i = 0; i < nr; i++) {
+      		ans[j * nr + i] = x[j * nr + i] + v[j];
+    	}
+  	}
+  }
+  UNPROTECT(1);
+  return(R_ans);
+}
+
+
+
+
+
+SEXP _mvMult(SEXP R_m, SEXP R_v, SEXP R_by_row)
+{
+  int i, j;
+  int nr = nrows(R_m);
+  int nc = ncols(R_m);
+  double *x = REAL(R_m);
+  double *v = REAL(R_v);
+  int by_row = asLogical(R_by_row); 
+
+  // If the length of the vector and the length of the corresponding dimension of the matrix do not match, throw an error
+  if  (!by_row) {
+  	if (LENGTH(R_v) != nc ) {
+    	error("The length of the vector must match the number of columns in the matrix");
+    	}
+  }
+  if ( by_row) {
+  	if (LENGTH(R_v) != nr ) {
+  		error("The length of the vector must match the number of rows in the matrix");
+  	}
+  }
+
+  // Allocate a variable for the return matrix
+  SEXP R_ans;
+  PROTECT(R_ans = allocMatrix(REALSXP, nr, nc));
+  // Set a pointer to the return matrix and initialize the memory
+  double *ans = REAL(R_ans);
+  Memzero(ans, nr * nc);
+
+  if (by_row) { 
+  	// element-wise multiplication of the i-th row of the matrix to i-th element of the vector
+  	for (j = 0; j < nc; j++) {
+    	for (i = 0; i < nr; i++) {
+      		ans[j * nr + i] = x[j * nr + i] * v[i];
+  		}
+  	}
+  }
+  if (!by_row) {
+  	// element-wise multiplication of the j-th column of the matrix to j-th element of the vector
+  	for (j = 0; j < nc; j++) {
+    	for (i = 0; i < nr; i++) {
+      		ans[j * nr + i] = x[j * nr + i] * v[j];
+    	}
+  	}
+  }
+  UNPROTECT(1);
+  return(R_ans);
+}
+
+
+
+
+
+SEXP _rowSumByGroup_real(SEXP R_x, SEXP R_group)
+{
+  int i, j;
+  int nr = nrows(R_x);
+  int nc = ncols(R_x);
+  double *x = REAL(R_x);
+
+  // If the grouping variable is not a factor, throw an error
+  if (!isFactor(R_group)) {
+    error("The grouping argument must be a factor");
+  }
+
+  int *group = INTEGER(R_group);
+  int nl = nlevels(R_group);
+  // If the sizes of the grouping variable and matrix do not match, throw an error
+  if (LENGTH(R_group) != nr) {
+    error("The length of the grouping argument must match the number of rows in the matrix");
+  }
+
+  // Allocate a variable for the return matrix
+  SEXP R_ans;
+  PROTECT(R_ans = allocMatrix(REALSXP, nl, nc));
+  // Set a pointer to the return matrix and initialize the memory
+  double *ans = REAL(R_ans);
+  Memzero(ans, nl * nc);
+
+  // Sum the totals for each element of the 'group' variable
+  // Note: columns are iterated over before rows because the compiler appears to store expressions like
+  //       'j * nr' in a temporary variable (as they do not change within inner loop);
+  //       swapping the order of the outer and inner loops slows down the code ~10X
+  for (j = 0; j < nc; j++) {
+    for (i = 0; i < nr; i++) {
+      ans[j * nl + group[i] - 1] += x[j * nr + i];
+    }
+  }
+
+  UNPROTECT(1);
+  return(R_ans);
+}
+
+
+
+SEXP _colSumByGroup_real(SEXP R_x, SEXP R_group)
+{
+  int i, j;
+  int nr = nrows(R_x);
+  int nc = ncols(R_x);
+  double *x = REAL(R_x);
+
+  // If the grouping variable is not a factor, throw an error
+  if (!isFactor(R_group)) {
+    error("The grouping argument must be a factor");
+  }
+
+  int *group = INTEGER(R_group);
+  int nl = nlevels(R_group);
+  // If the sizes of the grouping variable and matrix do not match, throw an error
+  if (LENGTH(R_group) != nc) {
+    error("The length of the grouping argument must match the number of columns in the matrix");
+  }
+  
+  // Allocate a variable for the return matrix
+  SEXP R_ans;
+  PROTECT(R_ans = allocMatrix(REALSXP, nr, nl));
+  // Set a pointer to the return matrix and initialize the memory
+  double *ans = REAL(R_ans);
+  Memzero(ans, nr * nl);
+
+  // Sum the totals for each element of the 'group' variable
+  // Note: columns are iterated over before rows because the compiler appears to store expressions like
+  //       'j * nr' in a temporary variable (as they do not change within inner loop);
+  //       swapping the order of the outer and inner loops slows down the code ~10X
+  for (j = 0; j < nc; j++) {
+    for (i = 0; i < nr; i++) {
+      ans[(group[j] - 1) * nr + i] += x[j * nr + i];
+    }
+  }
+
+  UNPROTECT(1);
+  return(R_ans);
+}
+
+
 

--- a/src/matrixSums.c
+++ b/src/matrixSums.c
@@ -286,7 +286,7 @@ SEXP _mvMult(SEXP R_m, SEXP R_v, SEXP R_by_row)
 
 
 
-SEXP _rowSumByGroup_real(SEXP R_x, SEXP R_group)
+SEXP _rowSumByGroup_numeric(SEXP R_x, SEXP R_group)
 {
   int i, j;
   int nr = nrows(R_x);
@@ -328,7 +328,7 @@ SEXP _rowSumByGroup_real(SEXP R_x, SEXP R_group)
 
 
 
-SEXP _colSumByGroup_real(SEXP R_x, SEXP R_group)
+SEXP _colSumByGroup_numeric(SEXP R_x, SEXP R_group)
 {
   int i, j;
   int nr = nrows(R_x);


### PR DESCRIPTION
normalizeCounts.internal  is a wrapper function of "_mvMult" to normalize counts matrix, for internal usage only, as unable to keep the column/row names 